### PR TITLE
string_utils: remove unnecessary semicolon

### DIFF
--- a/include/inicpp/string_utils.h
+++ b/include/inicpp/string_utils.h
@@ -130,7 +130,7 @@ namespace inicpp
 		using std::to_string;
 		/** Custom to_string method for enum_ini_t type */
 		std::string to_string(const enum_ini_t &value);
-	}; // namespace inistd
+	} // namespace inistd
 } // namespace inicpp
 
 #endif // INICPP_STRING_UTILS_H


### PR DESCRIPTION
This fixes warning when compiling with `-pedantic`

```
[1/18] Building CXX object CMakeFiles/inicpp_static.dir/src/config.cpp.o
In file included from ../include/inicpp/option.h:12,
                 from ../include/inicpp/config.h:10,
                 from ../src/config.cpp:1:
../include/inicpp/string_utils.h:133:3: warning: extra ';' [-Wpedantic]
  133 |  }; // namespace inistd
      |   ^
```