### PR TITLE
Fix target_compile_options error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,10 @@ else()
 endif()
 
 add_library(${PROJECT_NAME}_private_options INTERFACE)
-if(UNIX)
-	target_compile_options(${PROJECT_NAME}_private_options INTERFACE -Wall -Wextra -Wdeprecated -Wconversion -Wold-style-cast -Wformat)
-else()
+if(MSVC)
 	target_compile_options(${PROJECT_NAME}_private_options INTERFACE /W4)
+else()
+	target_compile_options(${PROJECT_NAME}_private_options INTERFACE -Wall -Wextra -Wdeprecated -Wconversion -Wold-style-cast -Wformat)
 endif()
 
 add_library(${PROJECT_NAME}_public_options INTERFACE)


### PR DESCRIPTION
Using Mingw to compile on Windows, CMake will select the '/W4' compile option, which will cause the following error

Problems were encountered while collecting compiler information:
	c++.exe: error: /W4: No such file or directory

c++.exe: error: /W4: No such file or directory