### PR TITLE
fix error when value is less than prefix

### DIFF
--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -107,7 +107,8 @@ namespace inicpp
 		{
 			try {
 				std::string binary_prefix = "0b";
-				if (value.size() > binary_prefix.size() && std::equal(binary_prefix.begin(), binary_prefix.end(), value.begin())) {
+				if (value.size() > binary_prefix.size() && 
+				    	std::equal(binary_prefix.begin(), binary_prefix.end(), value.begin())) {
 					// this is binary number
 					return std::stoll(value.substr(2), 0, 2);
 				} else {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -107,7 +107,7 @@ namespace inicpp
 		{
 			try {
 				std::string binary_prefix = "0b";
-				if (std::equal(binary_prefix.begin(), binary_prefix.end(), value.begin())) {
+				if (value.size() > binary_prefix.size() && std::equal(binary_prefix.begin(), binary_prefix.end(), value.begin())) {
 					// this is binary number
 					return std::stoll(value.substr(2), 0, 2);
 				} else {


### PR DESCRIPTION
When value is less than value, equal will report an error: cannot seek string iterator after end

![image](https://user-images.githubusercontent.com/12003087/179340888-07454c79-9783-490c-be57-cd974b311b03.png)
